### PR TITLE
Fixing "No valid jobid found in block" caused by backslashes

### DIFF
--- a/sources/proc_common.go
+++ b/sources/proc_common.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	numRegexPattern      = regexp.MustCompile(`[0-9]*\.[0-9]+|[0-9]+`)
-	jobidRegexPattern    = regexp.MustCompile(`(?m:job_id: *"?([\d\w\-_.:+/() ]*)"?$)`)
+	jobidRegexPattern    = regexp.MustCompile(`(?m:job_id: *"?([\d\w\-_.:+/() \\]*)"?$)`)
 	jobStatsRegexPattern = regexp.MustCompile(`(?ms:job_id:.*?$.*?(?:-|\z))`)
 )
 


### PR DESCRIPTION
There are some jobs, such as "kworker/48:0" that get encoded as "kworker\x2F48\x3A0" and this was breaking the regex lookup.

This is an example of the error message before the patch:

```
2025-08-25T09:44:10.075078-04:00 lustre06-oss1a lustre_exporter[1407693]: time="2025-08-25T09:44:10-04:00" level=error msg="No valid jobid found in block: job_id:          \"kworker\\x2F25\\x3A0.0\"\n  snapshot_time:   1756129209.209
772928 secs.nsecs\n  start_time:      1756129209.209771330 secs.nsecs\n  elapsed_time:    0.000001598 secs.nsecs\n  read_bytes:      { samples:           0, unit: bytes, min:        0, max:        0, sum:                0, sumsq:
              0 }\n  write_bytes:     { samples:           0, unit: bytes, min:        0, max:        0, sum:                0, sumsq:                  0 }\n  read:            { samples:           0, unit: usecs, min:        0, max:
       0, sum:                0, sumsq:                  0 }\n  write:           { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }\n  getattr:         { samples:
       0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }\n  setattr:         { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:
     0 }\n  punch:           { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }\n  sync:            { samples:           0, unit: usecs, min:        0, max:        0,
 sum:                0, sumsq:                  0 }\n  destroy:         { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }\n  create:          { samples:           0,
 unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }\n  statfs:          { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }\
n  get_info:        { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }\n  set_info:        { samples:           1, unit: usecs, min:        7, max:        7, sum:
            7, sumsq:                 49 }\n  quotactl:        { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }\n  prealloc:        { samples:           0, unit: us
ecs, min:        0, max:        0, sum:                0, sumsq:                  0 }\n-"
```